### PR TITLE
Small improvements to batch editing tickets

### DIFF
--- a/app/admin/tickets.rb
+++ b/app/admin/tickets.rb
@@ -55,7 +55,7 @@ ActiveAdmin.register Ticket, :sort_order => "ticket_priority_id_desc" do
     @statuses = TicketStatus.all
     @categories = TicketCategory.all
     @priorities = TicketPriority.all
-    @prompt = "&raquo; No Change &laquo;"
+    @prompt = "No Change"
     render 'multiple_edit_form'
   end
   

--- a/app/views/tickets/multiple_edit_form.html.haml
+++ b/app/views/tickets/multiple_edit_form.html.haml
@@ -23,6 +23,6 @@
 	%fieldset.buttons
 		%ol
 			%li.commit.button
-				= submit_tag "Update Tickets", disable_with: "Saving..."
+				= submit_tag "Update Tickets", disable_with: "Saving...", data: { confirm: "Update these tickets?" }
 			%li.cancel
 				= link_to "Cancel", collection_path


### PR DESCRIPTION
Fixed annoying quote issue when editing multiple tickets, and add a confirmation prompt before updating.

![screen shot 2013-05-10 at 6 52 41 pm](https://f.cloud.github.com/assets/162970/490617/6eb380c8-b9c4-11e2-99e3-9a2e36a4eeed.png)
