### PR TITLE
Incorrect link to client on Projects#show

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -71,7 +71,7 @@ ActiveAdmin.register Project, :sort_order => "number_asc" do
       attributes_table_for resource do
         row :number
         row :name
-        row :client
+        row(:client) { link_to resource.client.display_name, [active_admin_namespace.name, resource.client] }
         row(:hourly_rate) { number_to_currency resource.hourly_rate } unless current_admin_user.employee?
         row :start_date do
           resource.start_date.humanize


### PR DESCRIPTION
When viewing a project, the link to the associated client on Projects#show would link incorrectly to "clients/:id" instead of using the correct routing param.
