### PR TITLE
JavaScript Runtime error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'rails', '3.2.13'
 gem 'actionpack', '3.2.13' # added b/c google_charts gem isn't being a good citizen in gemspec
 
-gem 'pg'  
+gem 'pg'
 gem 'foreman'
 gem 'thin'
 
@@ -37,6 +37,7 @@ gem 'date_validator'
 group :assets do
   gem 'coffee-rails', '~> 3.2.1'
   gem 'uglifier', '>= 1.0.3'
+  gem 'therubyracer'
 end
 
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
+    libv8 (3.11.8.17)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -151,6 +152,7 @@ GEM
     rake (10.0.4)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     responders (0.9.1)
       railties (~> 3.1)
     sass (3.1.15)
@@ -166,6 +168,9 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     stringex (1.3.2)
     subexec (0.2.2)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thin (1.3.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -210,6 +215,7 @@ DEPENDENCIES
   sass-rails
   settingslogic
   stringex
+  therubyracer
   thin
   turn (= 0.8.2)
   uglifier (>= 1.0.3)


### PR DESCRIPTION
When I tried to start the server i came across the following error:

/.rvm/gems/ruby-1.9.3-p392/gems/execjs-1.3.0/lib/execjs/runtimes.rb:50:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)

adding the rubyracer gem to the Gemfile solved the problem
