### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,10 @@ RUN bundle exec rake assets:precompile && \
     /etc/init.d/postgresql start && \
     bundle exec rake db:create db:setup
 
+# Ensure PostgreSQL permissions are correct
+RUN chmod 750 /etc/ssl/private/ && \
+    chmod 640 /etc/ssl/private/ssl-cert-snakeoil.key
+
 EXPOSE 3000
 
 # Run the Rails server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# SprintApp web application Docker image
+#
+# VERSION       1.0
+
+# ~~~~ Image base ~~~~
+FROM litaio/ruby
+MAINTAINER zedtux, zedtux@zedroot.org
+
+
+# ~~~~ OS Maintenance ~~~~
+# Keep up-to-date the container OS
+RUN apt-get update && apt-get upgrade -y
+# Install required header files for PostgreSQL in order to install pg gem
+RUN apt-get install -y libpq-dev
+
+
+# ~~~~ Rails Preparation ~~~~
+# Global gem configuration
+RUN touch ~/.gemrc && echo "gem: --no-ri --no-rdoc" >> ~/.gemrc
+# Rubygems
+RUN gem install rubygems-update
+RUN update_rubygems
+# Bundler
+RUN gem install bundler
+# Copy the Gemfile and Gemfile.lock into the image.
+# Temporarily set the working directory to where they are.
+RUN mkdir -p /sprintapp/bundler/
+ADD Gemfile /sprintapp/bundler/Gemfile
+ADD Gemfile.lock /sprintapp/bundler/Gemfile.lock
+WORKDIR /sprintapp/bundler/
+RUN bundle --deployment --without development test
+# ~~~~ Sources Preparation ~~~~
+# Prepare application source folder
+RUN mkdir /sprintapp/application/
+WORKDIR /sprintapp/application/
+# Import the source code (look at the .dockerignore file)
+ADD . /sprintapp/application/
+
+RUN bundle exec rake assets:precompile RAILS_ENV=production
+
+EXPOSE 3000
+
+# Run the Rails server
+# CMD bundle exec rake db:setup
+ENTRYPOINT bundle exec rails server thin

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN mkdir -p /sprintapp/
 WORKDIR /sprintapp/
 # Import the source code (look at the .dockerignore file)
 ADD . /sprintapp/
+# Fix Rails assets access
+RUN sed -i "s/config.assets.compile = false/config.assets.compile = true/" config/environments/$RAILS_ENV.rb
 # Copy default database config file and update it
 RUN cp config/database.yml.sample config/database.yml && \
     echo "\nproduction:"  >> config/database.yml && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,36 @@
 FROM zedtux/ruby-1.9.3
 MAINTAINER zedtux, zedtux@zedroot.org
 
+ENV POSTGRESQL_VERSION 9.3
+ENV USERNAME sprintapp
+ENV DB_PASSWORD ''
+ENV DATABASE_NAME 'sprint_app_development'
 
-# ~~~~ OS Maintenance ~~~~
-# Keep up-to-date the container OS
-RUN apt-get update && \
-  apt-get upgrade -y && \
-  apt-get install -y git \
-    libpq-dev \
-    build-essential
+# ~~~~ PostgreSQL ~~~~
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update && apt-get install -y python-software-properties \
+  software-properties-common \
+  postgresql-$POSTGRESQL_VERSION \
+  postgresql-client-$POSTGRESQL_VERSION \
+  postgresql-contrib-$POSTGRESQL_VERSION \
+  git \
+  libpq-dev \
+  build-essential
 
+# Login as postgres user
+USER postgres
+# Enable listening on all network devises
+RUN sed -i -e "s/.*listen_addresses.*/listen_addresses = '*'/g" /etc/postgresql/$POSTGRESQL_VERSION/main/postgresql.conf
+# Use md5 authentication mechanism for all IPv4 connections
+RUN echo "host\tall\tall\t0.0.0.0/0\tmd5" >> /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
+RUN echo "local\tall\tall\t\tmd5" >> /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
+# Start PostgreSQL and update postgres user in order to remove the password
+RUN /etc/init.d/postgresql start && \
+    psql --command "CREATE USER $USERNAME WITH ENCRYPTED PASSWORD '$DB_PASSWORD';" && \
+    createdb --owner=$USERNAME --template=template0 --encoding=UTF8 $DATABASE_NAME
+
+USER root
 
 # ~~~~ Rails Preparation ~~~~
 # Global gem configuration
@@ -26,29 +47,20 @@ RUN update_rubygems
 RUN gem install bundler
 # Copy the Gemfile and Gemfile.lock into the image.
 # Temporarily set the working directory to where they are.
-RUN mkdir -p /sprintapp/bundler/
-ADD Gemfile /sprintapp/bundler/Gemfile
-ADD Gemfile.lock /sprintapp/bundler/Gemfile.lock
-WORKDIR /sprintapp/bundler/
+RUN mkdir -p /sprintapp/
+WORKDIR /sprintapp/
+# Import the source code (look at the .dockerignore file)
+ADD . /sprintapp/
+# Copy default database config file
+RUN cp config/database.yml.sample config/database.yml
 
 RUN bundle config build.eventmachine "--with-cflags=\"-O2 -pipe -march=native -w\""
 RUN bundle config build.thin "--with-cflags=\"-O2 -pipe -march=native -w\""
 RUN bundle --deployment --without development test
 
-# ~~~~ Sources Preparation ~~~~
-# Prepare application source folder
-RUN mkdir /sprintapp/application/
-WORKDIR /sprintapp/application/
-# Import the source code (look at the .dockerignore file)
-ADD . /sprintapp/application/
-
-RUN ls -al
-RUN bundle exec gem list
-
 EXPOSE 3000
 
 # Run the Rails server
-# CMD bundle exec rake db:setup
-# ENTRYPOINT bundle exec rails server thin
-
-# CMD bundle exec rails server thin
+ENTRYPOINT /etc/init.d/postgresql start && \
+  bundle exec rake db:setup && \
+  bundle exec rails server thin

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN echo "\nproduction:"  >> config/database.yml && \
     echo "  <<: *pg"  >> config/database.yml && \
     echo "  username: <%= ENV['DB_USERNAME'] %>"  >> config/database.yml && \
     echo "  password: <%= ENV['DB_PASSWORD'] %>" >> config/database.yml && \
-    echo "  database: <%= ENV['$DATABASE_NAME'] %>\n" >> config/database.yml
+    echo "  database: <%= ENV['DATABASE_NAME'] %>\n" >> config/database.yml
 RUN cat config/database.yml
 
 RUN bundle config build.eventmachine "--with-cflags=\"-O2 -pipe -march=native -w\""

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER zedtux, zedtux@zedroot.org
 ENV POSTGRESQL_VERSION 9.3
 ENV DB_USERNAME sprintapp
 ENV DB_PASSWORD sprintapp
-ENV DATABASE_NAME sprint_app_development
+ENV DATABASE_NAME sprint_app_production
 ENV RAILS_ENV production
 
 # ~~~~ PostgreSQL ~~~~
@@ -30,7 +30,6 @@ USER postgres
 RUN sed -i -e "s/.*listen_addresses.*/listen_addresses = '*'/g" /etc/postgresql/$POSTGRESQL_VERSION/main/postgresql.conf
 # Use md5 authentication mechanism for local connections
 RUN sed -i 's/local   all             all                                     peer/local   all             all                                     md5/' /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
-RUN cat /etc/postgresql/$POSTGRESQL_VERSION/main/pg_hba.conf
 
 # Start PostgreSQL and update postgres user in order to remove the password
 RUN /etc/init.d/postgresql start && \
@@ -42,8 +41,7 @@ USER root
 # Global gem configuration
 RUN touch ~/.gemrc && echo "gem: --no-ri --no-rdoc" >> ~/.gemrc
 # Rubygems
-RUN gem install rubygems-update
-RUN update_rubygems
+RUN gem install rubygems-update && update_rubygems
 # Bundler
 RUN gem install bundler
 # Copy the Gemfile and Gemfile.lock into the image.
@@ -53,21 +51,24 @@ WORKDIR /sprintapp/
 # Import the source code (look at the .dockerignore file)
 ADD . /sprintapp/
 # Copy default database config file and update it
-RUN cp config/database.yml.sample config/database.yml
-RUN echo "\nproduction:"  >> config/database.yml && \
+RUN cp config/database.yml.sample config/database.yml && \
+    echo "\nproduction:"  >> config/database.yml && \
     echo "  <<: *pg"  >> config/database.yml && \
+    echo "  template: template0"  >> config/database.yml && \
     echo "  username: <%= ENV['DB_USERNAME'] %>"  >> config/database.yml && \
     echo "  password: <%= ENV['DB_PASSWORD'] %>" >> config/database.yml && \
     echo "  database: <%= ENV['DATABASE_NAME'] %>\n" >> config/database.yml
-RUN cat config/database.yml
 
 RUN bundle config build.eventmachine "--with-cflags=\"-O2 -pipe -march=native -w\""
 RUN bundle config build.thin "--with-cflags=\"-O2 -pipe -march=native -w\""
 RUN bundle --deployment --without development test
 
+RUN bundle exec rake assets:precompile && \
+    /etc/init.d/postgresql start && \
+    bundle exec rake db:create db:setup
+
 EXPOSE 3000
 
 # Run the Rails server
 ENTRYPOINT /etc/init.d/postgresql start && \
-  bundle exec rake db:create db:setup && \
-  bundle exec rails server thin
+           bundle exec rails server thin

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '1.9.3'
 
 gem 'rails', '3.2.13'
 gem 'actionpack', '3.2.13' # added b/c google_charts gem isn't being a good citizen in gemspec
+gem 'rake'
 
 gem 'pg'
 gem 'foreman'
@@ -49,7 +50,6 @@ group :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'shoulda-matchers'
-  gem 'rake'
   gem 'faker'
   gem 'timecop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'settingslogic'
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'rspec-rails'
 end
 
 # Assets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # SprintApp
 [![Build Status](https://travis-ci.org/macfanatic/SprintApp.png)](https://travis-ci.org/macfanatic/SprintApp)
 
+
+## DEPRECATED
+This project has not seen any community contributions for a year now, and I have not had time for the project, or the need, for an even longer period of time.
+
+If you're interested in becoming a contributor, please hit me up on twitter at [@macfanatic](https://twitter.com/macfanatic)
+
+## Overview
+
 Project management and time tracking should be easy. SprintApp is simple to use so you can focus on running your business and focus on what you do best.  [Redmine](http://www.redmine.org) is great for some teams, but we think it's difficult to use and doesn't look that great.  SprintApp aims to solve those issues and more!
 
 ## Features

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -2,7 +2,6 @@ pg: &pg
   adapter: postgresql
   encoding: unicode
   pool: 5
-  username: sprintapp
 
 development:
   <<: *pg

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -2,6 +2,7 @@ pg: &pg
   adapter: postgresql
   encoding: unicode
   pool: 5
+  username: sprintapp
 
 development:
   <<: *pg


### PR DESCRIPTION
This pull request import a Dockerfile which allows you to use Docker (http://docker.com) in order to run/deploy SprintApp.

How to use it:

```
$ cd /path/to/SprintApp
$ docker build -t macfanatic/sprintapp .
$ docker run --rm --name sprintapp -p 80:3000 -t macfanatic/sprintapp
```

For non Linux users (Windows and Mac), you're using boot2docker so you need to know the IP address:
    $ boot2docker ip

Take the IP address and use it on your web browser and you should have SprintApp login screen.

TODO: Allow to mount a volume of the database data so that you're not going loose your data when restarting the docker container.
